### PR TITLE
Fix mobile navigation and responsive overflow

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -19,13 +19,86 @@
 <link rel="stylesheet" href="/css/subnav.css">
 <link rel="stylesheet" href="/css/subnav_research.css">
 <script>
-  function redirectToResearch() {
-    window.location.href = '/research/index.html';
-  }
+  document.addEventListener("DOMContentLoaded", function () {
+    const header = document.querySelector("header[data-mobile-menu]");
+    if (!header) return;
+
+    const menuButton = header.querySelector(".mobile_menu_toggle");
+    const navigation = header.querySelector("#site-navigation");
+    const mobileQuery = window.matchMedia("(max-width: 600px)");
+
+    function setSubnavOpen(container, open) {
+      const button = container.querySelector(".subnavbtn, .subnavbtn-research");
+
+      container.setAttribute("data-subnav-open", open ? "true" : "false");
+      if (button) button.setAttribute("aria-expanded", open ? "true" : "false");
+    }
+
+    function closeSubnavs(except) {
+      header.querySelectorAll(".subnav, .subnav-research").forEach(function (container) {
+        if (container !== except) setSubnavOpen(container, false);
+      });
+    }
+
+    function setMobileMenuOpen(open) {
+      header.setAttribute("data-mobile-menu-open", open ? "true" : "false");
+      if (menuButton) {
+        menuButton.setAttribute("aria-expanded", open ? "true" : "false");
+        menuButton.setAttribute("aria-label", open ? "Close navigation" : "Open navigation");
+      }
+      if (!open) closeSubnavs();
+    }
+
+    if (menuButton && navigation) {
+      menuButton.addEventListener("click", function () {
+        setMobileMenuOpen(header.getAttribute("data-mobile-menu-open") !== "true");
+      });
+
+      navigation.addEventListener("click", function (event) {
+        const link = event.target instanceof Element ? event.target.closest("a") : null;
+        if (link && mobileQuery.matches) setMobileMenuOpen(false);
+      });
+    }
+
+    header.querySelectorAll(".subnav, .subnav-research").forEach(function (container) {
+      const button = container.querySelector(".subnavbtn, .subnavbtn-research");
+      if (!button) return;
+
+      button.addEventListener("click", function () {
+        const target = button.getAttribute("data-nav-target");
+
+        if (!mobileQuery.matches) {
+          if (target) window.location.href = target;
+          return;
+        }
+
+        const nextOpen = container.getAttribute("data-subnav-open") !== "true";
+        closeSubnavs(container);
+        setSubnavOpen(container, nextOpen);
+      });
+    });
+
+    document.addEventListener("keydown", function (event) {
+      if (event.key === "Escape") setMobileMenuOpen(false);
+    });
+
+    function handleViewportChange() {
+      if (!mobileQuery.matches) {
+        setMobileMenuOpen(false);
+        closeSubnavs();
+      }
+    }
+
+    if (mobileQuery.addEventListener) {
+      mobileQuery.addEventListener("change", handleViewportChange);
+    } else {
+      mobileQuery.addListener(handleViewportChange);
+    }
+  });
 </script>
 
 
-<header {% if background %}class="background"{% endif %} {% if background %}style="--background: url('{{ background | relative_url }}')"{% endif %} data-dark="{{ dark }}">
+<header {% if background %}class="background"{% endif %} {% if background %}style="--background: url('{{ background | relative_url }}')"{% endif %} data-dark="{{ dark }}" data-mobile-menu data-mobile-menu-open="false">
   <a
     href="{{ '/' | relative_url }}"
     class="logo_row"
@@ -37,12 +110,30 @@
     {% endif %}
   </a>
 
-  <div class="navbar">
+  <button
+    class="mobile_menu_toggle"
+    type="button"
+    aria-label="Open navigation"
+    aria-controls="site-navigation"
+    aria-expanded="false"
+  >
+    <i class="fa fa-bars" aria-hidden="true"></i>
+  </button>
+
+  <nav class="navbar" id="site-navigation" aria-label="Primary navigation">
     <a href="{{ '/' | relative_url }}">Home</a>
 
-    <div class="subnav-research">
-      <button class="subnavbtn-research" onclick="redirectToResearch()">Research</button>
-      <div class="subnav-research-content">
+    <div class="subnav-research" data-subnav-open="false">
+      <button
+        class="subnavbtn-research"
+        type="button"
+        data-nav-target="/research/index.html"
+        aria-haspopup="true"
+        aria-controls="research-subnav"
+        aria-expanded="false"
+      >Research</button>
+      <div class="subnav-research-content" id="research-subnav">
+        <a href="/research/index.html">Overview</a>
         <a href="/research/mobile_manipulator/">Mobile Manipulator</a>
         <a href="/research/exoskeleton_robot/">Exoskeleton Robot</a>
         <a href="/research/artificial_intelligence/">Artificial Intelligence</a>
@@ -53,30 +144,48 @@
 
     <a href="/project/index.html">Projects</a>
 
-    <div class="subnav">
-      <button class="subnavbtn">Publications <i class="fa fa-caret-down"></i></button>
-      <div class="subnav-content">
+    <div class="subnav" data-subnav-open="false">
+      <button
+        class="subnavbtn"
+        type="button"
+        aria-haspopup="true"
+        aria-controls="publications-subnav"
+        aria-expanded="false"
+      >Publications <i class="fa fa-caret-down" aria-hidden="true"></i></button>
+      <div class="subnav-content" id="publications-subnav">
         <a href="/publication/index.html">Journal &amp; Conference Papers</a>
         <a href="/publication/patent.html">Patents</a>
       </div>
     </div>
 
-    <div class="subnav">
-      <button class="subnavbtn">Team <i class="fa fa-caret-down"></i></button>
-      <div class="subnav-content">
+    <div class="subnav" data-subnav-open="false">
+      <button
+        class="subnavbtn"
+        type="button"
+        aria-haspopup="true"
+        aria-controls="team-subnav"
+        aria-expanded="false"
+      >Team <i class="fa fa-caret-down" aria-hidden="true"></i></button>
+      <div class="subnav-content" id="team-subnav">
         <a href="/team/index.html">Members</a>
         <a href="/contact/index.html">Contact</a>
       </div>
     </div>
 
-    <div class="subnav">
-      <button class="subnavbtn">News &amp; Events <i class="fa fa-caret-down"></i></button>
-      <div class="subnav-content">
+    <div class="subnav" data-subnav-open="false">
+      <button
+        class="subnavbtn"
+        type="button"
+        aria-haspopup="true"
+        aria-controls="news-subnav"
+        aria-expanded="false"
+      >News &amp; Events <i class="fa fa-caret-down" aria-hidden="true"></i></button>
+      <div class="subnav-content" id="news-subnav">
         <a href="/news/index.html">News</a>
         <a href="/workshop/index.html">Workshops</a>
         <a href="/lecture/index.html">Lectures</a>
       </div>
     </div>
-  </div>
+  </nav>
 
 </header>

--- a/css/event_grid.css
+++ b/css/event_grid.css
@@ -1,7 +1,28 @@
 
 .event_container {
     display: grid;
-    grid-template-columns: 40% 1fr;
+    grid-template-columns: minmax(0, 40%) minmax(0, 1fr);
     grid-gap: 10px;
+    max-width: 100%;
 
+}
+
+.event_container > * {
+    min-width: 0;
+}
+
+.event_container img {
+    max-width: 100%;
+    height: auto;
+}
+
+.event_container .items {
+    min-width: 0;
+    overflow-wrap: anywhere;
+}
+
+@media (max-width: 640px) {
+    .event_container {
+        grid-template-columns: 1fr;
+    }
 }

--- a/css/footer.scss
+++ b/css/footer.scss
@@ -28,6 +28,8 @@ footer {
   }
 
   .footer_col {
+    min-width: 0;
+
     h4 {
       margin: 0 0 8px;
       font-size: 0.72rem;
@@ -81,6 +83,7 @@ footer {
     grid-template-columns: max-content max-content;
     gap: 4px 24px;
     justify-content: start;
+    max-width: 100%;
 
     li {
       white-space: nowrap;
@@ -118,6 +121,15 @@ footer {
   @media (max-width: 500px) {
     .footer_inner {
       grid-template-columns: 1fr;
+    }
+
+    .footer_explore_grid {
+      grid-template-columns: 1fr;
+      gap: 4px;
+
+      li {
+        white-space: normal;
+      }
     }
   }
 }

--- a/css/header.scss
+++ b/css/header.scss
@@ -28,6 +28,7 @@ header {
   .logo_row {
     @include inline-flex-center;
     gap: 12px;
+    min-width: 0;
 
     .logo {
       max-width: 100%;
@@ -44,6 +45,27 @@ header {
       line-height: 1.2;
       text-align: left;
       color: $accent;
+    }
+  }
+
+  .mobile_menu_toggle {
+    display: none;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+    padding: 0;
+    color: $accent;
+    background: rgba(255, 255, 255, 0.9);
+    border: 1px solid rgba(17, 35, 73, 0.12);
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 1.1rem;
+    line-height: 1;
+
+    &:focus-visible {
+      outline: 2px solid $accent;
+      outline-offset: 2px;
     }
   }
 
@@ -89,16 +111,38 @@ header {
     align-content: center;
     padding: 10px 16px;
 
-    .logo_row,
     .nav_row {
       width: 100%;
     }
   }
 
   @media (max-width: 600px) {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 8px 12px;
+    padding: 10px 14px;
+
     .logo_row {
-      flex-direction: column;
+      justify-content: flex-start;
       gap: 8px;
+
+      .logo {
+        flex: 0 0 auto;
+        height: 1.2rem !important;
+      }
+
+      .logo_text,
+      div {
+        min-width: 0;
+        font-size: 0.98rem !important;
+        line-height: 1.15;
+        overflow-wrap: anywhere;
+      }
+    }
+
+    .mobile_menu_toggle {
+      display: inline-flex;
+      justify-self: end;
     }
 
     .nav_row {
@@ -109,6 +153,10 @@ header {
       .link {
         width: 100%;
       }
+    }
+
+    .navbar {
+      grid-column: 1 / -1;
     }
   }
 }

--- a/css/organizer_grid.css
+++ b/css/organizer_grid.css
@@ -1,9 +1,24 @@
 
 .organizer_container {
     display: grid;
-    grid-template-columns: 20% 1fr;
+    grid-template-columns: minmax(0, 20%) minmax(0, 1fr);
     grid-gap: 10px;
+    max-width: 100%;
+    overflow-wrap: anywhere;
 
 }
 
+.organizer_container > * {
+    min-width: 0;
+}
 
+.organizer_container img {
+    max-width: 100%;
+    height: auto;
+}
+
+@media (max-width: 640px) {
+    .organizer_container {
+        grid-template-columns: 1fr;
+    }
+}

--- a/css/project_grid.css
+++ b/css/project_grid.css
@@ -1,10 +1,30 @@
 
 .event_container {
     display: grid;
-    grid-template-columns: 30% 1fr;
+    grid-template-columns: minmax(0, 30%) minmax(0, 1fr);
     grid-template-rows: 100%;
     grid-gap: 10px;
+    max-width: 100%;
 
 }
 
+.event_container > * {
+    min-width: 0;
+}
 
+.event_container img {
+    max-width: 100%;
+    height: auto;
+}
+
+.event_container .items {
+    min-width: 0;
+    overflow-wrap: anywhere;
+}
+
+@media (max-width: 640px) {
+    .event_container {
+        grid-template-columns: 1fr;
+        grid-template-rows: auto;
+    }
+}

--- a/css/section.scss
+++ b/css/section.scss
@@ -10,6 +10,7 @@ body {
   margin: 0;
   padding: 0;
   min-height: 100vh;
+  max-width: 100%;
 }
 
 body {
@@ -26,15 +27,18 @@ body {
     display: flex;
     flex-direction: column;
     flex-grow: 1;
+    min-width: 0;
   }
 
   section {
     .section {
-      box-sizing: content-box;
+      box-sizing: border-box;
+      width: 100%;
       max-width: $page;
       margin: 0 auto;
       padding: 32px 40px;
       text-align: left;
+      overflow-wrap: break-word;
     }
   }
 
@@ -44,5 +48,15 @@ body {
 
   section:last-of-type {
     flex-grow: 1;
+  }
+}
+
+@media (max-width: 600px) {
+  body {
+    section {
+      .section {
+        padding: 24px 20px;
+      }
+    }
   }
 }

--- a/css/subnav.css
+++ b/css/subnav.css
@@ -3,8 +3,10 @@
   position: static;
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 4px;
   background-color: transparent;
+  min-width: 0;
 }
 
 /* Navigation links */
@@ -25,6 +27,7 @@
 /* Subnav container */
 .subnav {
   position: relative;
+  min-width: 0;
 }
 
 /* Subnav button */
@@ -62,6 +65,8 @@
   backdrop-filter: saturate(160%) blur(14px);
   -webkit-backdrop-filter: saturate(160%) blur(14px);
   min-width: 220px;
+  max-width: calc(100vw - 32px);
+  box-sizing: border-box;
   border: 1px solid rgba(17, 35, 73, 0.08);
   border-top: 2px solid #1f3b6e;
   z-index: 50;
@@ -94,4 +99,64 @@
 /* Open dropdown on hover */
 .subnav:hover .subnav-content {
   display: block;
+}
+
+.subnav:focus-within .subnav-content,
+.subnav[data-subnav-open="true"] .subnav-content {
+  display: block;
+}
+
+@media (max-width: 900px) {
+  .navbar {
+    width: 100%;
+    justify-content: center;
+  }
+}
+
+@media (max-width: 600px) {
+  .navbar {
+    display: none;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 2px;
+    padding-top: 8px;
+    margin-top: 8px;
+    border-top: 1px solid rgba(17, 35, 73, 0.12);
+  }
+
+  header[data-mobile-menu-open="true"] .navbar {
+    display: flex;
+  }
+
+  .navbar a,
+  .subnav .subnavbtn {
+    box-sizing: border-box;
+    justify-content: center;
+    width: 100%;
+  }
+
+  .subnav {
+    width: 100%;
+  }
+
+  .subnav-content {
+    position: static;
+    min-width: 0;
+    width: 100%;
+    max-width: 100%;
+    box-shadow: none;
+  }
+
+  .subnav:focus-within .subnav-content {
+    display: none;
+  }
+
+  .subnav[data-subnav-open="true"] .subnav-content {
+    display: block;
+  }
+
+  .subnav-content a {
+    padding-left: 28px;
+    text-align: center;
+  }
 }

--- a/css/subnav_research.css
+++ b/css/subnav_research.css
@@ -1,6 +1,7 @@
 /* Research subnav - white glass header */
 .subnav-research {
   position: relative;
+  min-width: 0;
 }
 
 .subnav-research .subnavbtn-research {
@@ -34,6 +35,8 @@
   backdrop-filter: saturate(160%) blur(14px);
   -webkit-backdrop-filter: saturate(160%) blur(14px);
   min-width: 240px;
+  max-width: calc(100vw - 32px);
+  box-sizing: border-box;
   border: 1px solid rgba(17, 35, 73, 0.08);
   border-top: 2px solid #1f3b6e;
   z-index: 50;
@@ -61,4 +64,42 @@
 
 .subnav-research:hover .subnav-research-content {
   display: block;
+}
+
+.subnav-research:focus-within .subnav-research-content,
+.subnav-research[data-subnav-open="true"] .subnav-research-content {
+  display: block;
+}
+
+@media (max-width: 600px) {
+  .subnav-research,
+  .subnav-research .subnavbtn-research {
+    box-sizing: border-box;
+    width: 100%;
+  }
+
+  .subnav-research .subnavbtn-research {
+    text-align: center;
+  }
+
+  .subnav-research-content {
+    position: static;
+    min-width: 0;
+    width: 100%;
+    max-width: 100%;
+    box-shadow: none;
+  }
+
+  .subnav-research:focus-within .subnav-research-content {
+    display: none;
+  }
+
+  .subnav-research[data-subnav-open="true"] .subnav-research-content {
+    display: block;
+  }
+
+  .subnav-research-content a {
+    padding-left: 28px;
+    text-align: center;
+  }
 }

--- a/css/two-col.scss
+++ b/css/two-col.scss
@@ -7,8 +7,13 @@
 
 .two_col {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   grid-gap: 20px;
+
+  > * {
+    min-width: 0;
+    overflow-wrap: anywhere;
+  }
 
   @media (max-width: $phone) {
     grid-template-columns: 1fr;

--- a/index.md
+++ b/index.md
@@ -228,7 +228,7 @@ layout: default
   }
   .home_news_list a {
     display: grid;
-    grid-template-columns: 110px 1fr;
+    grid-template-columns: 110px minmax(0, 1fr);
     align-items: baseline;
     gap: 18px;
     padding: 8px 0;
@@ -237,6 +237,9 @@ layout: default
     transition: color 0.15s ease;
   }
   .home_news_list a:hover { color: #1f3b6e; }
+  .home_news_list a > * {
+    min-width: 0;
+  }
   .home_news_list time {
     font-family: "Inter", sans-serif;
     font-size: 0.85rem;
@@ -248,6 +251,7 @@ layout: default
   .home_news_list .home_news_title {
     font-size: 0.98rem;
     line-height: 1.4;
+    overflow-wrap: anywhere;
   }
 
   /* YouTube strip */
@@ -282,13 +286,14 @@ layout: default
   .home_youtube_more:hover { color: #112349; }
   .home_youtube_grid {
     display: grid;
-    grid-template-columns: repeat(2, 1fr);
+    grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: 22px;
     max-width: 880px;
   }
   .home_youtube_card {
     display: flex;
     flex-direction: column;
+    min-width: 0;
     text-decoration: none;
     color: #1d1d1b;
     transition: color 0.15s ease, transform 0.2s ease;
@@ -332,6 +337,7 @@ layout: default
     flex-direction: column;
     gap: 4px;
     padding: 10px 0 0;
+    min-width: 0;
   }
   .home_youtube_meta time {
     font-family: "Inter", sans-serif;
@@ -348,6 +354,7 @@ layout: default
     display: -webkit-box;
     -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;
+    overflow-wrap: anywhere;
     overflow: hidden;
     transition: color 0.15s ease;
   }
@@ -360,11 +367,17 @@ layout: default
   }
   @media (max-width: 700px) {
     .home_title { font-size: 1.55rem; }
-    .home_news_list a { grid-template-columns: 92px 1fr; gap: 12px; }
+    .home_news_list a { grid-template-columns: 92px minmax(0, 1fr); gap: 12px; }
     .home_news_list .home_news_title { font-size: 0.92rem; }
     .home_youtube { padding: 24px 20px 16px; }
-    .home_youtube_grid { grid-template-columns: 1fr 1fr; gap: 12px; }
+    .home_youtube_grid { grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; }
     .home_youtube_title { font-size: 0.85rem; }
+  }
+  @media (max-width: 520px) {
+    .home_news { padding: 24px 20px 16px; }
+    .home_news_list a { grid-template-columns: 1fr; gap: 4px; }
+    .home_news_list time { white-space: normal; }
+    .home_youtube_grid { grid-template-columns: 1fr; }
   }
 </style>
 

--- a/tests/test_mobile_layout_guardrails.py
+++ b/tests/test_mobile_layout_guardrails.py
@@ -1,0 +1,171 @@
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read_repo_file(path):
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+class MobileLayoutGuardrailsTest(unittest.TestCase):
+    def assert_has_mobile_single_column_rule(self, css, selector, max_width="640px"):
+        pattern = (
+            rf"@media\s*\(max-width:\s*{re.escape(max_width)}\)\s*{{"
+            rf"[\s\S]*?{re.escape(selector)}\s*{{"
+            rf"[\s\S]*?grid-template-columns:\s*1fr\s*;"
+        )
+        self.assertRegex(css, pattern)
+
+    def test_content_sections_use_border_box_width_on_small_viewports(self):
+        section_css = read_repo_file("css/section.scss")
+
+        self.assertRegex(
+            section_css,
+            r"\.section\s*{[\s\S]*?box-sizing:\s*border-box\s*;",
+        )
+        self.assertRegex(
+            section_css,
+            r"\.section\s*{[\s\S]*?width:\s*100%\s*;",
+        )
+
+    def test_event_style_grids_stack_and_allow_children_to_shrink(self):
+        for path in ("css/project_grid.css", "css/event_grid.css"):
+            css = read_repo_file(path)
+
+            with self.subTest(path=path):
+                self.assertRegex(css, r"\.event_container\s*>\s*\*\s*{[\s\S]*?min-width:\s*0\s*;")
+                self.assertRegex(css, r"\.event_container\s+\.items\s*{[\s\S]*?overflow-wrap:\s*anywhere\s*;")
+                self.assert_has_mobile_single_column_rule(css, ".event_container")
+
+    def test_organizer_grid_stacks_and_allows_children_to_shrink(self):
+        css = read_repo_file("css/organizer_grid.css")
+
+        self.assertRegex(css, r"\.organizer_container\s*>\s*\*\s*{[\s\S]*?min-width:\s*0\s*;")
+        self.assertRegex(css, r"\.organizer_container\s*{[\s\S]*?overflow-wrap:\s*anywhere\s*;")
+        self.assert_has_mobile_single_column_rule(css, ".organizer_container")
+
+    def test_homepage_mobile_lists_collapse_to_single_column(self):
+        homepage = read_repo_file("index.md")
+
+        self.assertRegex(homepage, r"\.home_news_list\s+a\s*>\s*\*\s*{[\s\S]*?min-width:\s*0\s*;")
+        self.assertRegex(homepage, r"\.home_news_list\s+\.home_news_title\s*{[\s\S]*?overflow-wrap:\s*anywhere\s*;")
+        self.assert_has_mobile_single_column_rule(homepage, ".home_news_list a", max_width="520px")
+        self.assert_has_mobile_single_column_rule(homepage, ".home_youtube_grid", max_width="520px")
+
+    def test_footer_explore_links_stack_on_narrow_screens(self):
+        footer_css = read_repo_file("css/footer.scss")
+
+        self.assertRegex(footer_css, r"\.footer_col\s*{[\s\S]*?min-width:\s*0\s*;")
+        self.assertRegex(
+            footer_css,
+            r"@media\s*\(max-width:\s*500px\)\s*{[\s\S]*?\.footer_explore_grid\s*{"
+            r"[\s\S]*?grid-template-columns:\s*1fr\s*;",
+        )
+        self.assertRegex(
+            footer_css,
+            r"@media\s*\(max-width:\s*500px\)\s*{[\s\S]*?\.footer_explore_grid\s*{[\s\S]*?li\s*{"
+            r"[\s\S]*?white-space:\s*normal\s*;",
+        )
+
+    def test_header_navigation_wraps_instead_of_widening_the_viewport(self):
+        subnav_css = read_repo_file("css/subnav.css")
+        research_subnav_css = read_repo_file("css/subnav_research.css")
+
+        self.assertRegex(subnav_css, r"\.navbar\s*{[\s\S]*?flex-wrap:\s*wrap\s*;")
+        self.assertRegex(subnav_css, r"\.navbar\s*{[\s\S]*?min-width:\s*0\s*;")
+        self.assertRegex(
+            subnav_css,
+            r"@media\s*\(max-width:\s*600px\)\s*{[\s\S]*?\.navbar\s*{[\s\S]*?flex-direction:\s*column\s*;",
+        )
+        self.assertRegex(
+            subnav_css,
+            r"@media\s*\(max-width:\s*600px\)\s*{[\s\S]*?\.subnav-content\s*{[\s\S]*?min-width:\s*0\s*;",
+        )
+        self.assertRegex(
+            research_subnav_css,
+            r"@media\s*\(max-width:\s*600px\)\s*{[\s\S]*?\.subnav-research-content\s*{"
+            r"[\s\S]*?min-width:\s*0\s*;",
+        )
+
+    def test_header_has_accessible_mobile_menu_toggle(self):
+        header = read_repo_file("_includes/header.html")
+
+        self.assertIn('data-mobile-menu-open="false"', header)
+        self.assertRegex(header, r'<button\s+[^>]*class="mobile_menu_toggle"')
+        self.assertRegex(header, r'class="mobile_menu_toggle"[\s\S]*?aria-controls="site-navigation"')
+        self.assertRegex(header, r'class="mobile_menu_toggle"[\s\S]*?aria-expanded="false"')
+        self.assertRegex(header, r'<nav\s+class="navbar"\s+id="site-navigation"\s+aria-label="Primary navigation"')
+        self.assertIn("setMobileMenuOpen", header)
+        self.assertIn("data-mobile-menu-open", header)
+
+    def test_mobile_navigation_is_hidden_until_the_hamburger_opens_it(self):
+        header_css = read_repo_file("css/header.scss")
+        subnav_css = read_repo_file("css/subnav.css")
+
+        self.assertRegex(header_css, r"\.mobile_menu_toggle\s*{[\s\S]*?display:\s*none\s*;")
+        self.assertRegex(
+            header_css,
+            r"@media\s*\(max-width:\s*600px\)\s*{[\s\S]*?\.mobile_menu_toggle\s*{"
+            r"[\s\S]*?display:\s*inline-flex\s*;",
+        )
+        self.assertRegex(
+            subnav_css,
+            r"@media\s*\(max-width:\s*600px\)\s*{[\s\S]*?\.navbar\s*{"
+            r"[\s\S]*?display:\s*none\s*;",
+        )
+        self.assertRegex(
+            subnav_css,
+            r"@media\s*\(max-width:\s*600px\)\s*{[\s\S]*?header\[data-mobile-menu-open=\"true\"\]\s+\.navbar\s*{"
+            r"[\s\S]*?display:\s*flex\s*;",
+        )
+
+    def test_mobile_submenus_open_from_button_state(self):
+        header = read_repo_file("_includes/header.html")
+        subnav_css = read_repo_file("css/subnav.css")
+        research_subnav_css = read_repo_file("css/subnav_research.css")
+
+        self.assertIn('aria-controls="research-subnav"', header)
+        self.assertIn('aria-controls="publications-subnav"', header)
+        self.assertIn('aria-controls="team-subnav"', header)
+        self.assertIn('aria-controls="news-subnav"', header)
+        self.assertIn("setSubnavOpen", header)
+        self.assertIn("data-subnav-open", header)
+        self.assertRegex(
+            subnav_css,
+            r"\.subnav\[data-subnav-open=\"true\"\]\s+\.subnav-content\s*{[\s\S]*?display:\s*block\s*;",
+        )
+        self.assertRegex(
+            research_subnav_css,
+            r"\.subnav-research\[data-subnav-open=\"true\"\]\s+\.subnav-research-content\s*{"
+            r"[\s\S]*?display:\s*block\s*;",
+        )
+
+    def test_mobile_menu_script_handles_link_clicks_defensively(self):
+        header = read_repo_file("_includes/header.html")
+
+        self.assertNotIn("function redirectToResearch", header)
+        self.assertIn("event.target instanceof Element", header)
+        self.assertNotRegex(header, r"const\s+link\s*=\s*event\.target\.closest\(\"a\"\)")
+
+    def test_subnav_state_is_only_toggled_on_mobile(self):
+        header = read_repo_file("_includes/header.html")
+
+        self.assertRegex(
+            header,
+            r"if\s*\(!mobileQuery\.matches\)\s*{[\s\S]*?if\s*\(target\)\s*window\.location\.href\s*=\s*target;"
+            r"[\s\S]*?return;",
+        )
+
+    def test_two_column_blocks_allow_children_to_shrink_before_stacking(self):
+        two_col_css = read_repo_file("css/two-col.scss")
+
+        self.assertRegex(two_col_css, r"\.two_col\s*{[\s\S]*?grid-template-columns:\s*repeat\(2,\s*minmax\(0,\s*1fr\)\)\s*;")
+        self.assertRegex(two_col_css, r"\.two_col\s*{[\s\S]*?>\s*\*\s*{[\s\S]*?min-width:\s*0\s*;")
+        self.assertRegex(two_col_css, r"\.two_col\s*{[\s\S]*?>\s*\*\s*{[\s\S]*?overflow-wrap:\s*anywhere\s*;")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Collapse the mobile navigation behind an accessible hamburger menu.
- Prevent horizontal overflow by tightening responsive grid, footer, homepage, and content section styles.
- Add regression tests for mobile layout guardrails and menu state behavior.

## Verification
- `python3 -m unittest discover tests`
- `rbenv exec bundle exec jekyll build`
- `node --check /private/tmp/hyharco-header.js`
- Headless Chrome mobile check for `/`, `/project/`, and `/workshop/`