### PR TITLE
Stabilize publication updates and manual sync workflows

### DIFF
--- a/.github/workflows/sync_gitlab.yml
+++ b/.github/workflows/sync_gitlab.yml
@@ -5,14 +5,33 @@ on:
     branches: [ "main" ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   push-to-gitlab:
+    if: ${{ vars.ENABLE_GITLAB_SYNC == 'true' }}
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Validate GitLab sync configuration
+        env:
+          GITLAB_URL: ${{ secrets.GITLAB_URL }}
+          GITLAB_USERNAME: ${{ secrets.GITLAB_USERNAME }}
+          GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
+        run: |
+          missing=0
+          for variable in GITLAB_URL GITLAB_USERNAME GITLAB_TOKEN; do
+            if [[ -z "${!variable}" ]]; then
+              echo "::error::$variable secret is required when ENABLE_GITLAB_SYNC is true."
+              missing=1
+            fi
+          done
+          exit "$missing"
 
       - name: Set remote repository
         env:

--- a/.github/workflows/update-publications.yml
+++ b/.github/workflows/update-publications.yml
@@ -1,18 +1,16 @@
 name: Update Publications
 
 on:
-  schedule:
-    - cron: "17 19 * * *" # Daily at 04:17 KST
-  push:
-    branches:
-      - main
-    paths:
-      - ".github/workflows/update-publications.yml"
-      - "_data/publication_overrides.yaml"
-      - "scripts/publication_pipeline.py"
-      - "scripts/scrape_scholar.py"
-      - "scripts/update_publications.py"
   workflow_dispatch:
+    inputs:
+      source:
+        description: "Publication source for the manual GitHub-hosted run"
+        required: true
+        type: choice
+        default: openalex
+        options:
+          - openalex
+          - scholar
 
 permissions:
   contents: write
@@ -38,7 +36,7 @@ jobs:
         run: python -m pip install requests pyyaml manubot
 
       - name: Run publication pipeline
-        run: python scripts/update_publications.py
+        run: python scripts/update_publications.py --source "${{ inputs.source }}"
 
       - name: Commit updated publication data
         uses: stefanzweifel/git-auto-commit-action@v4

--- a/README.md
+++ b/README.md
@@ -82,11 +82,13 @@ hyHarco.github.io/
 ├── js/                           # JavaScript files
 ├── scripts/                      # Automation scripts
 │   ├── start.sh                  # Start dev server
-│   ├── publication_pipeline.py   # Merge Scholar data, overrides, DOI metadata
+│   ├── fetch_openalex.py         # Optional OpenAlex publication fetcher
+│   ├── local_publication_sync.py # Cross-platform Scholar check, sync, and push
+│   ├── publication_pipeline.py   # Merge fetched data, overrides, DOI metadata
 │   ├── scrape_scholar.py         # Fetch and parse Google Scholar
 │   ├── update_publications.py    # Build publication/publications.json
 │   ├── scrape_youtube.py         # Scrape YouTube
-│   ├── update_publications.sh    # Local publication update wrapper
+│   ├── update_publications.sh    # POSIX publication update wrapper
 │   ├── update_patents_json.py    # Update patent JSON
 │   └── templates/                # Post templates
 ├── contact/                      # Contact page
@@ -95,7 +97,7 @@ hyHarco.github.io/
 ├── news/                         # News listing page
 ├── project/                      # Project listing page
 ├── publication/                  # Publications page and data JSON
-│   ├── publications.json         # Publication data (Google Scholar)
+│   ├── publications.json         # Generated publication data
 │   └── patents.json              # Patent data
 ├── research/                     # Research pages (mobile_manipulator, exoskeleton_robot, ai)
 ├── team/                         # Team page
@@ -279,32 +281,45 @@ For research posts about a single member, prefer the slug-prefixed filename: `YY
 
 **Manual Corrections:**
 Prefer editing `_data/publication_overrides.yaml` for corrections, DOI links,
-or publications that are not on Google Scholar yet. The generated site data
-still lives in `publication/publications.json`.
+or publications that are not indexed by Google Scholar yet. The generated site
+data still lives in `publication/publications.json`.
 
-**Automated Update (Google Scholar + overrides + DOI enrichment):**
+**Local Update (Google Scholar + existing data + overrides + DOI enrichment):**
+
+To check Google Scholar access without changing repository files:
 
 ```bash
-./scripts/update_publications.sh
+python scripts/local_publication_sync.py --check --no-enrich
 ```
 
-This will:
+This check works from any branch and with pending local changes. It writes only
+temporary output and cache files.
 
-1. Scrape publications from Google Scholar
-2. Apply `_data/publication_overrides.yaml`
-3. Enrich DOI entries through Manubot when enrichment is enabled
-4. Save the final data to `publication/publications.json`
-
-To skip DOI enrichment for a faster local run:
+To update the production publication data:
 
 ```bash
-./scripts/update_publications.sh --no-enrich
+python scripts/local_publication_sync.py
+```
+
+The production update will:
+
+1. Require a clean working tree on `main`
+2. Pull the latest `main`
+3. Fetch publications from Google Scholar
+4. Merge those results with the existing `publication/publications.json`
+5. Apply `_data/publication_overrides.yaml`
+6. Commit and push generated publication changes when they exist
+
+To create the local commit but skip pushing:
+
+```bash
+python scripts/local_publication_sync.py --no-push
 ```
 
 The GitHub Actions workflow `.github/workflows/update-publications.yml`
-also runs the same pipeline every day at 04:17 KST, or when related
-publication pipeline files are pushed to `main`, and commits generated
-publication data when it changes.
+is manual-only and remains available as a fallback. Its default source is
+OpenAlex; Google Scholar scraping should run from a local machine or lab server
+because GitHub-hosted runners can be blocked by Google Scholar.
 
 ### Updating YouTube Videos
 
@@ -338,7 +353,7 @@ Start local development server with live reload:
 
 ### `update_publications.sh`
 
-Update publications from Google Scholar, manual overrides, and DOI metadata:
+Update publications from Google Scholar, existing site data, manual overrides, and DOI metadata:
 
 ```bash
 ./scripts/update_publications.sh
@@ -347,13 +362,27 @@ Update publications from Google Scholar, manual overrides, and DOI metadata:
 Wraps `scripts/update_publications.py` and regenerates
 `publication/publications.json`.
 
-### `scrape_scholar.py`
+### `local_publication_sync.py`
 
-Fetch and parse the HARCO Google Scholar profile. This is used by the
-publication pipeline and can still write raw Scholar data directly:
+Cross-platform local sync entrypoint for macOS, Windows, and Linux:
 
 ```bash
-python3 scripts/scrape_scholar.py
+python scripts/local_publication_sync.py --check --no-enrich
+python scripts/local_publication_sync.py
+```
+
+`--check --no-enrich` verifies Scholar access using temporary files only. The
+default sync mode creates the Python virtual environment when needed, runs the
+Scholar publication pipeline, commits generated publication data with an English
+commit message, and pushes the selected branch.
+
+### `scrape_scholar.py`
+
+Fetch and parse the HARCO Google Scholar profile. This is the primary local
+publication source and can still write raw Scholar data directly:
+
+```bash
+python scripts/scrape_scholar.py
 ```
 
 ### `scrape_youtube.py`
@@ -368,7 +397,8 @@ into JSON for the publications page.
 **Requirements:**
 
 - Python 3
-- `update_publications.sh` creates a local virtual environment and installs `requests`, `pyyaml`, and `manubot`
+- `local_publication_sync.py` creates a local virtual environment and installs `requests`, `pyyaml`, and `manubot`
+- `.sh` helper scripts are for POSIX shells; use the Python entrypoints for macOS, Windows, and Linux compatibility
 - `update_patents_json.py` requires `openpyxl`
 
 ---

--- a/scripts/fetch_openalex.py
+++ b/scripts/fetch_openalex.py
@@ -1,0 +1,254 @@
+"""Fetch publications from OpenAlex, the API-backed Scholar replacement."""
+
+from __future__ import annotations
+
+import html
+import os
+import re
+from typing import Any
+
+try:
+    from publication_pipeline import categorize_publication, clean_text
+except ImportError:
+    from scripts.publication_pipeline import categorize_publication, clean_text
+
+OPENALEX_WORKS_URL = "https://api.openalex.org/works"
+DEFAULT_AUTHOR_IDS = ("A5101430480",)
+DEFAULT_INSTITUTION_IDS = ("I4575257",)
+DEFAULT_WORK_TYPES = ("article", "conference-paper")
+DEFAULT_AFFILIATION_KEYWORDS = (
+    "harco",
+    "hanyang",
+    "erica",
+    "robotics",
+    "mechatronics",
+    "human-robot",
+    "human robot",
+)
+SELECT_FIELDS = (
+    "id",
+    "doi",
+    "display_name",
+    "publication_year",
+    "type",
+    "is_retracted",
+    "authorships",
+    "primary_location",
+)
+SKIPPED_WORK_TYPES = {"retraction", "paratext"}
+
+
+def _split_csv(value: str | None) -> list[str]:
+    return [item.strip() for item in str(value or "").split(",") if item.strip()]
+
+
+def _openalex_id(value: str) -> str:
+    return clean_text(value).rstrip("/").rsplit("/", 1)[-1]
+
+
+def _strip_markup(value: Any) -> str:
+    return clean_text(re.sub(r"<[^>]+>", "", html.unescape(str(value or ""))))
+
+
+def _doi_value(value: Any) -> str:
+    doi = clean_text(value)
+    doi = re.sub(r"^doi:\s*", "", doi, flags=re.IGNORECASE)
+    doi = re.sub(r"^https?://(?:dx\.)?doi\.org/", "", doi, flags=re.IGNORECASE)
+    return doi
+
+
+def _work_link(work: dict[str, Any], location: dict[str, Any], doi: str) -> str:
+    landing_page_url = clean_text(location.get("landing_page_url"))
+    if landing_page_url:
+        return landing_page_url
+    if doi:
+        return f"https://doi.org/{doi}"
+    return clean_text(work.get("id"))
+
+
+def _work_venue(work: dict[str, Any], location: dict[str, Any]) -> str:
+    source = location.get("source") if isinstance(location.get("source"), dict) else {}
+    return (
+        clean_text(location.get("raw_source_name"))
+        or clean_text(source.get("display_name"))
+        or clean_text(location.get("raw_type"))
+        or clean_text(work.get("type"))
+    )
+
+
+def _work_category(work: dict[str, Any], location: dict[str, Any], venue: str) -> str:
+    source = location.get("source") if isinstance(location.get("source"), dict) else {}
+    work_type = clean_text(work.get("type")).casefold()
+    source_type = clean_text(source.get("type")).casefold()
+    raw_type = clean_text(location.get("raw_type")).casefold()
+
+    if work_type == "conference-paper" or source_type == "conference" or "proceedings" in raw_type:
+        return "conference"
+    return categorize_publication(venue)
+
+
+def _work_authors(work: dict[str, Any]) -> str:
+    authors = []
+    for authorship in work.get("authorships", []):
+        if not isinstance(authorship, dict):
+            continue
+        author = authorship.get("author") if isinstance(authorship.get("author"), dict) else {}
+        name = clean_text(authorship.get("raw_author_name")) or clean_text(author.get("display_name"))
+        if name:
+            authors.append(name)
+    return ", ".join(authors)
+
+
+def _authorship_institution_ids(authorship: dict[str, Any]) -> set[str]:
+    institution_ids = set()
+    for institution in authorship.get("institutions", []):
+        if isinstance(institution, dict):
+            institution_id = clean_text(institution.get("id"))
+            if institution_id:
+                institution_ids.add(_openalex_id(institution_id))
+    return institution_ids
+
+
+def _authorship_affiliation_text(authorship: dict[str, Any]) -> str:
+    values = []
+    for field in ("raw_affiliation_strings", "affiliations"):
+        for item in authorship.get(field, []):
+            if isinstance(item, dict):
+                values.append(clean_text(item.get("raw_affiliation_string")))
+            else:
+                values.append(clean_text(item))
+    return " ".join(value for value in values if value).casefold()
+
+
+def work_matches_selected_author(
+    work: dict[str, Any],
+    author_ids: list[str] | tuple[str, ...],
+    institution_ids: list[str] | tuple[str, ...],
+    affiliation_keywords: list[str] | tuple[str, ...] = DEFAULT_AFFILIATION_KEYWORDS,
+) -> bool:
+    selected_author_ids = {_openalex_id(author_id) for author_id in author_ids}
+    selected_institution_ids = {_openalex_id(institution_id) for institution_id in institution_ids}
+    selected_keywords = tuple(keyword.casefold() for keyword in affiliation_keywords if keyword)
+
+    for authorship in work.get("authorships", []):
+        if not isinstance(authorship, dict):
+            continue
+        author = authorship.get("author") if isinstance(authorship.get("author"), dict) else {}
+        author_id = _openalex_id(clean_text(author.get("id")))
+        if author_id not in selected_author_ids:
+            continue
+
+        if not selected_institution_ids:
+            return True
+
+        if _authorship_institution_ids(authorship) & selected_institution_ids:
+            return True
+
+        affiliation_text = _authorship_affiliation_text(authorship)
+        if affiliation_text and any(keyword in affiliation_text for keyword in selected_keywords):
+            return True
+
+    return False
+
+
+def map_openalex_work_to_publication(work: dict[str, Any]) -> dict[str, Any] | None:
+    work_type = clean_text(work.get("type")).casefold()
+    title = _strip_markup(work.get("display_name"))
+    year = int(work.get("publication_year") or 0)
+
+    if work.get("is_retracted") or work_type in SKIPPED_WORK_TYPES or title.casefold().startswith("retraction"):
+        return None
+
+    location = work.get("primary_location") if isinstance(work.get("primary_location"), dict) else {}
+    authors = _work_authors(work)
+    venue = _work_venue(work, location)
+
+    if not title or not year or not authors or not venue:
+        return None
+
+    doi = _doi_value(work.get("doi"))
+    publication = {
+        "title": title,
+        "authors": authors,
+        "year": year,
+        "journal": venue,
+        "link": _work_link(work, location, doi),
+        "category": _work_category(work, location, venue),
+    }
+    if doi:
+        publication["doi"] = doi
+    return publication
+
+
+def fetch_publications(
+    profile_url: str | None = None,
+    min_year: int = 2015,
+    author_ids: list[str] | tuple[str, ...] | None = None,
+    institution_ids: list[str] | tuple[str, ...] | None = None,
+    affiliation_keywords: list[str] | tuple[str, ...] = DEFAULT_AFFILIATION_KEYWORDS,
+    page_size: int = 100,
+    api_url: str = OPENALEX_WORKS_URL,
+) -> list[dict[str, Any]]:
+    try:
+        import requests
+    except ImportError as error:
+        raise RuntimeError("Install requests to fetch OpenAlex publications.") from error
+
+    selected_author_ids = tuple(author_ids or _split_csv(os.getenv("OPENALEX_AUTHOR_IDS")) or DEFAULT_AUTHOR_IDS)
+    selected_institution_ids = tuple(
+        institution_ids if institution_ids is not None else _split_csv(os.getenv("OPENALEX_INSTITUTION_IDS")) or DEFAULT_INSTITUTION_IDS
+    )
+
+    filters = [
+        f"authorships.author.id:{'|'.join(_openalex_id(author_id) for author_id in selected_author_ids)}",
+        f"publication_year:>{min_year - 1}",
+        f"type:{'|'.join(DEFAULT_WORK_TYPES)}",
+    ]
+    if selected_institution_ids:
+        filters.append(
+            "authorships.institutions.id:"
+            + "|".join(_openalex_id(institution_id) for institution_id in selected_institution_ids)
+        )
+
+    params = {
+        "filter": ",".join(filters),
+        "sort": "publication_year:desc",
+        "per_page": page_size,
+        "cursor": "*",
+        "select": ",".join(SELECT_FIELDS),
+    }
+
+    api_key = clean_text(os.getenv("OPENALEX_API_KEY"))
+    mailto = clean_text(os.getenv("OPENALEX_MAILTO"))
+    if api_key:
+        params["api_key"] = api_key
+    if mailto:
+        params["mailto"] = mailto
+
+    publications: list[dict[str, Any]] = []
+    seen: set[str] = set()
+
+    while True:
+        response = requests.get(api_url, params=params, timeout=30)
+        if response.status_code != 200:
+            raise RuntimeError(f"Failed to retrieve OpenAlex works. Status code: {response.status_code}")
+
+        payload = response.json()
+        for work in payload.get("results", []):
+            if not work_matches_selected_author(work, selected_author_ids, selected_institution_ids, affiliation_keywords):
+                continue
+            publication = map_openalex_work_to_publication(work)
+            if not publication:
+                continue
+            key = publication["title"].casefold()
+            if key in seen:
+                continue
+            seen.add(key)
+            publications.append(publication)
+
+        next_cursor = payload.get("meta", {}).get("next_cursor")
+        if not next_cursor:
+            break
+        params["cursor"] = next_cursor
+
+    return sorted(publications, key=lambda publication: (-publication["year"], publication["title"].casefold()))

--- a/scripts/local_publication_sync.py
+++ b/scripts/local_publication_sync.py
@@ -1,0 +1,163 @@
+"""Cross-platform local publication sync for Google Scholar updates."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+GENERATED_FILES = (
+    "publication/publications.json",
+    "_data/publication_metadata_cache.json",
+)
+COMMIT_SUBJECT = "Update publication data from local Scholar sync"
+COMMIT_BODY = "Refresh generated publication data from the local Google Scholar update pipeline."
+
+
+def venv_python_path(venv_dir: Path, os_name: str = os.name) -> Path:
+    if os_name == "nt":
+        return venv_dir / "Scripts" / "python.exe"
+    return venv_dir / "bin" / "python"
+
+
+def build_update_command(
+    python_executable: str,
+    no_enrich: bool = False,
+    output_path: Path | None = None,
+    cache_path: Path | None = None,
+) -> list[str]:
+    command = [
+        python_executable,
+        "scripts/update_publications.py",
+        "--source",
+        "scholar",
+        "--require-fetch-success",
+    ]
+    if output_path is not None:
+        command.extend(["--output", str(output_path)])
+    if cache_path is not None:
+        command.extend(["--cache", str(cache_path)])
+    if no_enrich:
+        command.append("--no-enrich")
+    return command
+
+
+def run(command: list[str], repo_root: Path, check: bool = True) -> subprocess.CompletedProcess[str]:
+    print("+ " + " ".join(command))
+    return subprocess.run(command, cwd=repo_root, check=check, text=True)
+
+
+def capture(command: list[str], repo_root: Path) -> str:
+    result = subprocess.run(command, cwd=repo_root, check=True, capture_output=True, text=True)
+    return result.stdout.strip()
+
+
+def ensure_clean_worktree(repo_root: Path) -> None:
+    status = capture(["git", "status", "--porcelain"], repo_root)
+    if status:
+        raise RuntimeError("Working tree has pending changes. Commit, stash, or discard them before local sync.")
+
+
+def ensure_branch(repo_root: Path, branch: str) -> None:
+    current_branch = capture(["git", "branch", "--show-current"], repo_root)
+    if current_branch != branch:
+        raise RuntimeError(f"Local publication sync must run on {branch}; current branch is {current_branch}.")
+
+
+def ensure_virtualenv(repo_root: Path) -> str:
+    venv_dir = repo_root / "venv"
+    python_path = venv_python_path(venv_dir)
+    if not python_path.exists():
+        run([sys.executable, "-m", "venv", str(venv_dir)], repo_root)
+
+    dependencies = ["requests", "pyyaml", "manubot"]
+    run([str(python_path), "-m", "pip", "install", "-q", "--disable-pip-version-check", *dependencies], repo_root)
+    return str(python_path)
+
+
+def has_staged_generated_changes(repo_root: Path) -> bool:
+    result = run(["git", "diff", "--cached", "--quiet", "--", *GENERATED_FILES], repo_root, check=False)
+    return result.returncode != 0
+
+
+def check_publications(no_enrich: bool) -> int:
+    repo_root = Path(__file__).resolve().parents[1]
+    python_path = ensure_virtualenv(repo_root)
+
+    with tempfile.TemporaryDirectory(prefix="harco-publication-check-") as temp_dir:
+        temp_path = Path(temp_dir)
+        output_path = temp_path / "publications.json"
+        cache_path = temp_path / "publication_metadata_cache.json"
+        run(
+            build_update_command(
+                python_path,
+                no_enrich=no_enrich,
+                output_path=output_path,
+                cache_path=cache_path,
+            ),
+            repo_root,
+        )
+
+    print("Publication check completed without changing repository files.")
+    return 0
+
+
+def sync_publications(branch: str, remote: str, no_enrich: bool, no_pull: bool, no_push: bool) -> int:
+    repo_root = Path(__file__).resolve().parents[1]
+    ensure_clean_worktree(repo_root)
+    ensure_branch(repo_root, branch)
+
+    if not no_pull:
+        run(["git", "pull", "--ff-only", remote, branch], repo_root)
+
+    python_path = ensure_virtualenv(repo_root)
+    run(build_update_command(python_path, no_enrich=no_enrich), repo_root)
+    run(["git", "add", "--", *GENERATED_FILES], repo_root)
+
+    if not has_staged_generated_changes(repo_root):
+        print("No publication changes to commit.")
+        return 0
+
+    run(["git", "commit", "-m", COMMIT_SUBJECT, "-m", COMMIT_BODY], repo_root)
+
+    if not no_push:
+        run(["git", "push", remote, branch], repo_root)
+
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Update HARCO publications locally from Google Scholar.")
+    parser.add_argument("--branch", default="main", help="Branch to update and push.")
+    parser.add_argument("--remote", default="origin", help="Git remote to pull from and push to.")
+    parser.add_argument("--no-enrich", action="store_true", help="Skip Manubot DOI enrichment.")
+    parser.add_argument("--no-pull", action="store_true", help="Skip the initial git pull.")
+    parser.add_argument("--no-push", action="store_true", help="Commit locally without pushing.")
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Fetch publications into temporary files without checking git state or changing repository files.",
+    )
+    args = parser.parse_args()
+
+    try:
+        if args.check:
+            return check_publications(no_enrich=args.no_enrich)
+
+        return sync_publications(
+            branch=args.branch,
+            remote=args.remote,
+            no_enrich=args.no_enrich,
+            no_pull=args.no_pull,
+            no_push=args.no_push,
+        )
+    except Exception as error:
+        print(f"Publication sync failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/publication_pipeline.py
+++ b/scripts/publication_pipeline.py
@@ -1,4 +1,4 @@
-"""Merge Scholar publications with manual overrides and citation metadata."""
+"""Merge fetched publications with manual overrides and citation metadata."""
 
 from __future__ import annotations
 
@@ -31,7 +31,7 @@ CitationLookup = Callable[[str], dict[str, Any]]
 
 
 def normalize_title(title: Any) -> str:
-    """Return a stable key for matching Scholar titles to overrides."""
+    """Return a stable key for matching fetched titles to overrides."""
     return re.sub(r"\s+", " ", str(title or "").strip()).casefold()
 
 
@@ -157,7 +157,7 @@ def merge_publications(
     citation_lookup: CitationLookup | None = None,
     citation_cache: dict[str, Any] | None = None,
 ) -> list[dict[str, Any]]:
-    """Return final site publications from Scholar rows plus optional overrides."""
+    """Return final site publications from fetched rows plus optional overrides."""
     cache = citation_cache if citation_cache is not None else {}
     overrides_by_title = _overrides_by_title(overrides)
     seen: set[str] = set()

--- a/scripts/update_publications.py
+++ b/scripts/update_publications.py
@@ -17,7 +17,8 @@ try:
         merge_publications,
         write_json_data,
     )
-    from scrape_scholar import DEFAULT_PROFILE_URL, fetch_publications
+    from fetch_openalex import fetch_publications as fetch_openalex_publications
+    from scrape_scholar import DEFAULT_PROFILE_URL, fetch_publications as fetch_scholar_publications
 except ImportError:
     from scripts.publication_pipeline import (
         DEFAULT_CACHE_PATH,
@@ -29,24 +30,57 @@ except ImportError:
         merge_publications,
         write_json_data,
     )
-    from scripts.scrape_scholar import DEFAULT_PROFILE_URL, fetch_publications
+    from scripts.fetch_openalex import fetch_publications as fetch_openalex_publications
+    from scripts.scrape_scholar import DEFAULT_PROFILE_URL, fetch_publications as fetch_scholar_publications
 
 Fetcher = Callable[..., list[dict]]
+FETCHERS = {
+    "openalex": fetch_openalex_publications,
+    "scholar": fetch_scholar_publications,
+}
 
 
 def update_publications(
-    fetcher: Fetcher = fetch_publications,
+    fetcher: Fetcher | None = None,
     output_path: str | Path = DEFAULT_OUTPUT_PATH,
     overrides_path: str | Path = DEFAULT_OVERRIDES_PATH,
     cache_path: str | Path = DEFAULT_CACHE_PATH,
     profile_url: str = DEFAULT_PROFILE_URL,
     min_year: int = 2015,
     enrich: bool = True,
+    source: str = "scholar",
+    require_fetch_success: bool = False,
 ) -> list[dict]:
-    raw_publications = fetcher(profile_url=profile_url, min_year=min_year)
+    if source not in FETCHERS:
+        raise ValueError(f"Unknown publication source: {source}")
+
+    selected_fetcher = fetcher or FETCHERS[source]
+    existing_publications = load_json_data(output_path, default=[])
+
+    try:
+        fetched_publications = selected_fetcher(profile_url=profile_url, min_year=min_year)
+    except Exception as error:
+        existing_count = len(existing_publications) if isinstance(existing_publications, list) else 0
+        if existing_count:
+            if require_fetch_success:
+                raise RuntimeError(f"Publication fetch failed: {error}") from error
+            print(
+                f"[WARN] Publication fetch failed with {error}; keeping existing output with "
+                f"{existing_count} publications."
+            )
+            return existing_publications
+        raise
+
     overrides = load_publication_overrides(overrides_path)
     citation_cache = load_json_data(cache_path, default={})
     citation_lookup = cite_with_manubot if enrich else None
+    existing_publication_list = existing_publications if isinstance(existing_publications, list) else []
+    raw_publications = fetched_publications + existing_publication_list
+
+    if not fetched_publications and existing_publication_list and require_fetch_success:
+        raise RuntimeError(
+            "No publications were fetched from the selected source; existing publication data was preserved."
+        )
 
     publications = merge_publications(
         raw_publications,
@@ -55,12 +89,16 @@ def update_publications(
         citation_cache=citation_cache,
     )
 
-    existing_publications = load_json_data(output_path, default=[])
     if not publications:
-        existing_count = len(existing_publications) if isinstance(existing_publications, list) else 0
         raise RuntimeError(
-            "Refusing to write empty publication data because the existing output contains "
-            f"{existing_count} publications. Check the Scholar fetch or parser before rerunning."
+            "No publications were generated and no existing publication data was available. "
+            "Check the publication source fetch or parser before rerunning."
+        )
+
+    if not fetched_publications and existing_publication_list:
+        print(
+            "[WARN] No publications were fetched; keeping existing output with "
+            f"{len(existing_publication_list)} publications."
         )
 
     write_json_data(output_path, publications)
@@ -72,12 +110,18 @@ def update_publications(
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Update HARCO publication data.")
+    parser.add_argument("--source", choices=sorted(FETCHERS), default="scholar")
     parser.add_argument("--output", default=str(DEFAULT_OUTPUT_PATH))
     parser.add_argument("--overrides", default=str(DEFAULT_OVERRIDES_PATH))
     parser.add_argument("--cache", default=str(DEFAULT_CACHE_PATH))
     parser.add_argument("--profile-url", default=DEFAULT_PROFILE_URL)
     parser.add_argument("--min-year", type=int, default=2015)
     parser.add_argument("--no-enrich", action="store_true", help="Skip Manubot DOI metadata enrichment.")
+    parser.add_argument(
+        "--require-fetch-success",
+        action="store_true",
+        help="Fail instead of silently preserving existing data when the selected source returns nothing.",
+    )
     args = parser.parse_args()
 
     publications = update_publications(
@@ -87,9 +131,11 @@ def main() -> int:
         profile_url=args.profile_url,
         min_year=args.min_year,
         enrich=not args.no_enrich,
+        source=args.source,
+        require_fetch_success=args.require_fetch_success,
     )
 
-    print(f"Saved {len(publications)} publications to {args.output}")
+    print(f"Publication data contains {len(publications)} publications at {args.output}")
     if publications:
         print("Latest publications:")
         for publication in publications[:3]:

--- a/tests/test_local_publication_sync.py
+++ b/tests/test_local_publication_sync.py
@@ -1,0 +1,68 @@
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from scripts import local_publication_sync
+from scripts.local_publication_sync import build_update_command, venv_python_path
+
+
+class LocalPublicationSyncTest(unittest.TestCase):
+    def test_update_command_uses_scholar_and_requires_fetch_success(self):
+        command = build_update_command(
+            "python",
+            no_enrich=True,
+            output_path=Path("tmp/publications.json"),
+            cache_path=Path("tmp/cache.json"),
+        )
+
+        self.assertEqual(
+            command,
+            [
+                "python",
+                "scripts/update_publications.py",
+                "--source",
+                "scholar",
+                "--require-fetch-success",
+                "--output",
+                "tmp/publications.json",
+                "--cache",
+                "tmp/cache.json",
+                "--no-enrich",
+            ],
+        )
+
+    def test_check_mode_uses_temporary_files_without_git_guards(self):
+        commands = []
+
+        def record_command(command, repo_root, check=True):
+            commands.append(command)
+
+        with (
+            patch.object(local_publication_sync, "ensure_clean_worktree") as ensure_clean_worktree,
+            patch.object(local_publication_sync, "ensure_branch") as ensure_branch,
+            patch.object(local_publication_sync, "ensure_virtualenv", return_value="python"),
+            patch.object(local_publication_sync, "run", side_effect=record_command),
+            patch("builtins.print"),
+        ):
+            local_publication_sync.check_publications(no_enrich=True)
+
+        ensure_clean_worktree.assert_not_called()
+        ensure_branch.assert_not_called()
+        self.assertEqual(len(commands), 1)
+
+        command = commands[0]
+        self.assertIn("--output", command)
+        self.assertIn("--cache", command)
+        self.assertIn("--no-enrich", command)
+        self.assertEqual(Path(command[command.index("--output") + 1]).name, "publications.json")
+        self.assertEqual(Path(command[command.index("--cache") + 1]).name, "publication_metadata_cache.json")
+
+    def test_venv_python_path_is_cross_platform(self):
+        venv_dir = Path("venv")
+
+        self.assertEqual(venv_python_path(venv_dir, os_name="nt"), venv_dir / "Scripts" / "python.exe")
+        self.assertEqual(venv_python_path(venv_dir, os_name="posix"), venv_dir / "bin" / "python")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_publication_pipeline.py
+++ b/tests/test_publication_pipeline.py
@@ -184,6 +184,127 @@ class PublicationPipelineTest(unittest.TestCase):
 
         self.assertEqual([publication["title"] for publication in merged], ["Alpha Paper", "Beta Paper"])
 
+    def test_openalex_work_is_mapped_to_site_publication(self):
+        from scripts.fetch_openalex import map_openalex_work_to_publication
+
+        publication = map_openalex_work_to_publication(
+            {
+                "id": "https://openalex.org/W123",
+                "doi": "https://doi.org/10.1109/example.2026.1234567",
+                "display_name": "Stable Variable Impedance Control",
+                "publication_year": 2026,
+                "type": "conference-paper",
+                "authorships": [
+                    {
+                        "raw_author_name": "Seungmin Choi",
+                        "author": {"display_name": "Seung-Min Choi"},
+                    },
+                    {
+                        "raw_author_name": "Wansoo Kim",
+                        "author": {"display_name": "Wansoo Kim"},
+                    },
+                ],
+                "primary_location": {
+                    "landing_page_url": "https://doi.org/10.1109/example.2026.1234567",
+                    "raw_source_name": "2026 IEEE/RSJ International Conference on Intelligent Robots and Systems",
+                    "source": {"display_name": "IROS", "type": "conference"},
+                    "raw_type": "proceedings-article",
+                },
+            }
+        )
+
+        self.assertEqual(
+            publication,
+            {
+                "title": "Stable Variable Impedance Control",
+                "authors": "Seungmin Choi, Wansoo Kim",
+                "year": 2026,
+                "journal": "2026 IEEE/RSJ International Conference on Intelligent Robots and Systems",
+                "link": "https://doi.org/10.1109/example.2026.1234567",
+                "category": "conference",
+                "doi": "10.1109/example.2026.1234567",
+            },
+        )
+
+    def test_openalex_retraction_work_is_skipped(self):
+        from scripts.fetch_openalex import map_openalex_work_to_publication
+
+        publication = map_openalex_work_to_publication(
+            {
+                "display_name": "Retraction Note: Some Paper",
+                "publication_year": 2026,
+                "type": "retraction",
+                "authorships": [{"author": {"display_name": "A Author"}}],
+                "primary_location": {"raw_source_name": "Some Journal"},
+            }
+        )
+
+        self.assertIsNone(publication)
+
+    def test_openalex_fetch_requires_target_author_affiliation_match(self):
+        sys.modules.pop("scripts.fetch_openalex", None)
+
+        response_payload = {
+            "meta": {"next_cursor": None},
+            "results": [
+                {
+                    "id": "https://openalex.org/W1",
+                    "display_name": "Correct Robotics Paper",
+                    "publication_year": 2026,
+                    "type": "article",
+                    "authorships": [
+                        {
+                            "author": {"id": "https://openalex.org/A5101430480", "display_name": "Wansoo Kim"},
+                            "raw_author_name": "Wansoo Kim",
+                            "institutions": [{"id": "https://openalex.org/I4575257"}],
+                        }
+                    ],
+                    "primary_location": {"raw_source_name": "IEEE Robotics and Automation Letters"},
+                },
+                {
+                    "id": "https://openalex.org/W2",
+                    "display_name": "Unrelated Biology Paper",
+                    "publication_year": 2026,
+                    "type": "article",
+                    "authorships": [
+                        {
+                            "author": {"id": "https://openalex.org/A5101430480", "display_name": "Wansoo Kim"},
+                            "raw_author_name": "Wansoo Kim",
+                            "institutions": [{"id": "https://openalex.org/I31419693"}],
+                            "raw_affiliation_strings": ["School of Life Science, Kyungpook National University"],
+                        },
+                        {
+                            "author": {"id": "https://openalex.org/A5026761651", "display_name": "Se-Hyeon Han"},
+                            "raw_author_name": "Se-Hyeon Han",
+                            "institutions": [{"id": "https://openalex.org/I4575257"}],
+                        },
+                    ],
+                    "primary_location": {"raw_source_name": "Life Sciences"},
+                },
+            ],
+        }
+
+        class FakeResponse:
+            status_code = 200
+
+            def json(self):
+                return response_payload
+
+        fake_requests = types.SimpleNamespace(get=lambda *args, **kwargs: FakeResponse())
+        previous_requests = sys.modules.get("requests")
+        sys.modules["requests"] = fake_requests
+        try:
+            from scripts.fetch_openalex import fetch_publications
+
+            publications = fetch_publications(author_ids=("A5101430480",), institution_ids=("I4575257",))
+        finally:
+            if previous_requests is None:
+                sys.modules.pop("requests", None)
+            else:
+                sys.modules["requests"] = previous_requests
+
+        self.assertEqual([publication["title"] for publication in publications], ["Correct Robotics Paper"])
+
     def test_update_publications_writes_merged_dataset(self):
         from scripts.update_publications import update_publications
 
@@ -213,7 +334,44 @@ class PublicationPipelineTest(unittest.TestCase):
             self.assertEqual(json.loads(output_path.read_text(encoding="utf-8"))[0]["title"], "Fetched Paper")
             self.assertFalse(cache_path.exists())
 
-    def test_update_publications_refuses_to_overwrite_existing_data_with_empty_results(self):
+    def test_update_publications_defaults_to_scholar_source(self):
+        import scripts.update_publications as module
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_path = Path(temp_dir) / "publications.json"
+            cache_path = Path(temp_dir) / "cache.json"
+            overrides_path = Path(temp_dir) / "missing_overrides.yaml"
+            original_fetchers = module.FETCHERS
+
+            def scholar_fetcher(**kwargs):
+                return [
+                    {
+                        "title": "Scholar Default Paper",
+                        "authors": "A Author",
+                        "year": 2026,
+                        "journal": "Robotics Journal, 2026",
+                        "link": "https://example.com/scholar",
+                        "category": "journal",
+                    }
+                ]
+
+            def openalex_fetcher(**kwargs):
+                raise AssertionError("OpenAlex should not be the default publication source")
+
+            module.FETCHERS = {"openalex": openalex_fetcher, "scholar": scholar_fetcher}
+            try:
+                publications = module.update_publications(
+                    output_path=output_path,
+                    overrides_path=overrides_path,
+                    cache_path=cache_path,
+                    enrich=False,
+                )
+            finally:
+                module.FETCHERS = original_fetchers
+
+            self.assertEqual(publications[0]["title"], "Scholar Default Paper")
+
+    def test_update_publications_merges_fetched_results_with_existing_dataset(self):
         from scripts.update_publications import update_publications
 
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -232,7 +390,99 @@ class PublicationPipelineTest(unittest.TestCase):
             ]
             output_path.write_text(json.dumps(existing_publications, ensure_ascii=False), encoding="utf-8")
 
-            with self.assertRaisesRegex(RuntimeError, "Refusing to write empty publication data"):
+            publications = update_publications(
+                fetcher=lambda **kwargs: [
+                    {
+                        "title": "Fetched Paper",
+                        "authors": "B Author",
+                        "year": 2026,
+                        "journal": "Robotics Conference, 2026",
+                        "link": "https://example.com/fetched",
+                        "category": "conference",
+                    }
+                ],
+                output_path=output_path,
+                overrides_path=overrides_path,
+                cache_path=cache_path,
+                enrich=False,
+            )
+
+            self.assertEqual([publication["title"] for publication in publications], ["Fetched Paper", "Existing Paper"])
+            self.assertEqual(
+                [publication["title"] for publication in json.loads(output_path.read_text(encoding="utf-8"))],
+                ["Fetched Paper", "Existing Paper"],
+            )
+
+    def test_update_publications_keeps_existing_data_when_fetch_returns_empty_results(self):
+        from scripts.update_publications import update_publications
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_path = Path(temp_dir) / "publications.json"
+            cache_path = Path(temp_dir) / "cache.json"
+            overrides_path = Path(temp_dir) / "missing_overrides.yaml"
+            existing_publications = [
+                {
+                    "title": "Existing Paper",
+                    "authors": "A Author",
+                    "year": 2025,
+                    "journal": "Robotics Journal, 2025",
+                    "link": "https://example.com/existing",
+                    "category": "journal",
+                }
+            ]
+            output_path.write_text(json.dumps(existing_publications, ensure_ascii=False), encoding="utf-8")
+
+            publications = update_publications(
+                fetcher=lambda **kwargs: [],
+                output_path=output_path,
+                overrides_path=overrides_path,
+                cache_path=cache_path,
+                enrich=False,
+            )
+
+            self.assertEqual(publications, existing_publications)
+            self.assertEqual(json.loads(output_path.read_text(encoding="utf-8")), existing_publications)
+
+    def test_update_publications_can_require_successful_fetch(self):
+        from scripts.update_publications import update_publications
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_path = Path(temp_dir) / "publications.json"
+            cache_path = Path(temp_dir) / "cache.json"
+            overrides_path = Path(temp_dir) / "missing_overrides.yaml"
+            existing_publications = [
+                {
+                    "title": "Existing Paper",
+                    "authors": "A Author",
+                    "year": 2025,
+                    "journal": "Robotics Journal, 2025",
+                    "link": "https://example.com/existing",
+                    "category": "journal",
+                }
+            ]
+            output_path.write_text(json.dumps(existing_publications, ensure_ascii=False), encoding="utf-8")
+
+            with self.assertRaisesRegex(RuntimeError, "No publications were fetched"):
+                update_publications(
+                    fetcher=lambda **kwargs: [],
+                    output_path=output_path,
+                    overrides_path=overrides_path,
+                    cache_path=cache_path,
+                    enrich=False,
+                    require_fetch_success=True,
+                )
+
+            self.assertEqual(json.loads(output_path.read_text(encoding="utf-8")), existing_publications)
+
+    def test_update_publications_fails_empty_initial_dataset(self):
+        from scripts.update_publications import update_publications
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_path = Path(temp_dir) / "publications.json"
+            cache_path = Path(temp_dir) / "cache.json"
+            overrides_path = Path(temp_dir) / "missing_overrides.yaml"
+
+            with self.assertRaisesRegex(RuntimeError, "No publications were generated"):
                 update_publications(
                     fetcher=lambda **kwargs: [],
                     output_path=output_path,
@@ -240,8 +490,6 @@ class PublicationPipelineTest(unittest.TestCase):
                     cache_path=cache_path,
                     enrich=False,
                 )
-
-            self.assertEqual(json.loads(output_path.read_text(encoding="utf-8")), existing_publications)
 
 
 if __name__ == "__main__":

--- a/tests/test_workflow_guardrails.py
+++ b/tests/test_workflow_guardrails.py
@@ -1,0 +1,21 @@
+import unittest
+from pathlib import Path
+
+
+class WorkflowGuardrailTest(unittest.TestCase):
+    def test_gitlab_sync_requires_explicit_enable_variable(self):
+        workflow = Path(".github/workflows/sync_gitlab.yml").read_text(encoding="utf-8")
+
+        self.assertIn("if: ${{ vars.ENABLE_GITLAB_SYNC == 'true' }}", workflow)
+        self.assertIn("ENABLE_GITLAB_SYNC", workflow)
+
+    def test_github_publication_update_is_manual_only(self):
+        workflow = Path(".github/workflows/update-publications.yml").read_text(encoding="utf-8")
+
+        self.assertIn("workflow_dispatch:", workflow)
+        self.assertNotIn("schedule:", workflow)
+        self.assertNotIn("push:", workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Keep the publication update workflow as a manual GitHub Actions fallback with OpenAlex as the default source.
- Add a cross-platform local Google Scholar sync command for macOS, Windows, and Linux.
- Add a safe Scholar check mode that uses temporary files and works even with pending local changes.
- Preserve existing publication data when a fetch fails or returns empty results.
- Disable GitLab sync by default unless `ENABLE_GITLAB_SYNC` is explicitly enabled.
- Update README documentation for the new publication update flow.

## Verification

- `python3 -m unittest discover tests`
- `git diff --check`
- `python3 -m py_compile scripts/local_publication_sync.py scripts/update_publications.py scripts/fetch_openalex.py scripts/scrape_scholar.py scripts/publication_pipeline.py`
- `rbenv exec bundle exec jekyll build`
- `python scripts/local_publication_sync.py --check --no-enrich`